### PR TITLE
feat(SVG): add width attribute as optional

### DIFF
--- a/Sources/QRCodeGenerator/QRCode.swift
+++ b/Sources/QRCodeGenerator/QRCode.swift
@@ -246,7 +246,7 @@ public struct QRCode {
     /// this QR Code, with the given number of border modules.
     /// 
     /// The string always uses Unix newlines (\n), regardless of the platform.
-    public func toSVGString(border: Int) -> String {
+    public func toSVGString(border: Int, width: Int? = nil) -> String {
         assert(border >= 0, "Border must be non-negative")
         let dimension = size + (border * 2)
         let path = (0..<size).map { y in
@@ -256,10 +256,11 @@ public struct QRCode {
                     : ""
             }.joined()
         }.joined()
+        let widthAttribute = width.map { "width=\($0)" } ?? ""
         return """
             <?xml version="1.0" encoding="UTF-8"?>
             <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 \(dimension) \(dimension)" stroke="none">
+            <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 \(dimension) \(dimension)" stroke="none"\(widthAttribute)>
               <rect width="100%" height="100%" fill="#FFFFFF"/>
               <path d="\(path)" fill="#000000"/>
             </svg>


### PR DESCRIPTION
* add Width attribute (optionally) so we can easily put a with to the
  generated SVG

A very tiny suggestion that we can directly add the width to the `svg` tag rather than manipulating it posteriorly.

And the code I wrote in my backend here: https://github.com/renaudjenny/steamScrum/blob/main/Sources/App/Controllers/UserStoryController.swift#L93

You can see an example of the result here: https://steam-scrum.herokuapp.com/grooming_sessions/48228904-4F32-47E4-B6A4-8E3AEA4CD573/user_stories/C9A485BB-F209-4EA9-8E7C-FF3CAB2C878E

Thank you very much to have ported this amazing library to Swift! That's amazing 👍