### PR TITLE
CocoaPods support

### DIFF
--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -1,0 +1,16 @@
+name: Darwin
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build SPM
+      run: swift build
+    - name: Test SPM
+      run: swift test
+    - name: Lint Podspec
+      run: pod lib lint --allow-warnings --use-libraries

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
       - "v*"
 
 jobs:
-  build:
+  deploy:
     runs-on: macOS-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - "!*"
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: macOS-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Deploy to CocoaPods
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      run: |
+        set -eo pipefail
+        export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1` | gawk 'match($0, /v(.+)/, o) { print o[1] }')
+        pod lib lint --allow-warnings
+        pod trunk push --allow-warnings

--- a/QRCodeGenerator.podspec
+++ b/QRCodeGenerator.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name                      = "QRCodeGenerator"
+  s.version                   = ENV["LIB_VERSION"] || "1.0.0"
+  s.summary                   = "QR code generator written in pure Swift"
+  s.homepage                  = "https://github.com/fwcd/swift-qrcode-generator"
+  s.license                   = { :type => "MIT", :file => "LICENSE" }
+  s.author                    = { "fwcd" => "fwcdmail@gmail.com" }
+  s.source                    = { :git => "https://github.com/fwcd/swift-qrcode-generator.git", :tag => "v#{s.version.to_s}" }
+  s.swift_version             = "5.1"
+  s.ios.deployment_target     = "9.0"
+  s.tvos.deployment_target    = "9.0"
+  s.watchos.deployment_target = "2.0"
+  s.osx.deployment_target     = "10.10"
+  s.source_files              = "Sources/**/*"
+  s.frameworks                = "Foundation"
+end

--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@ A QR code generator written in pure Swift with no dependencies.
 The project is mostly a direct translation of [Nayuki's](https://github.com/nayuki/) [QR code generator for Rust](https://github.com/nayuki/QR-Code-generator/tree/master/rust), with small changes applied to make the code more idiomatic in Swift.
 
 ## Usage
+
+### Swift Package Manager
 To use in your project, add the following dependency to your `Package.swift`:
 
 ```swift
 .package(url: "https://github.com/fwcd/swift-qrcode-generator.git", from: "1.0.0")
+```
+
+### CocoaPods
+Swift QR Code Generator is available through [CocoaPods](http://cocoapods.org). To install
+it, simply add the following line to your Podfile:
+
+```bash
+pod 'QRCodeGenerator'
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Swift QR Code Generator
 
 [![Linux](https://github.com/fwcd/swift-qrcode-generator/workflows/Linux/badge.svg)](https://github.com/fwcd/swift-qrcode-generator/actions)
+[![Darwin](https://github.com/fwcd/swift-qrcode-generator/workflows/Darwin/badge.svg)](https://github.com/fwcd/swift-qrcode-generator/actions)
 
 A QR code generator written in pure Swift with no dependencies.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Swift QR Code Generator is available through [CocoaPods](http://cocoapods.org). 
 it, simply add the following line to your Podfile:
 
 ```bash
-pod 'QRCodeGenerator'
+pod 'SwiftQRCodeGenerator'
 ```
 
 ## Example

--- a/SwiftQRCodeGenerator.podspec
+++ b/SwiftQRCodeGenerator.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = "9.0"
   s.watchos.deployment_target = "2.0"
   s.osx.deployment_target     = "10.10"
+  s.module_name               = 'QRCodeGenerator'
   s.source_files              = "Sources/**/*"
   s.frameworks                = "Foundation"
 end

--- a/SwiftQRCodeGenerator.podspec
+++ b/SwiftQRCodeGenerator.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name                      = "QRCodeGenerator"
+  s.name                      = "SwiftQRCodeGenerator"
   s.version                   = ENV["LIB_VERSION"] || "1.0.0"
   s.summary                   = "QR code generator written in pure Swift"
   s.homepage                  = "https://github.com/fwcd/swift-qrcode-generator"


### PR DESCRIPTION
Hi! So as it was discussed [there](https://github.com/fwcd/swift-qrcode-generator/issues/2) I am proposing this pull request to add support for CocoaPods. To enable automatic deployment you have to add repository secret named `COCOAPODS_TRUNK_TOKEN` following tutorial [here](https://medium.com/swlh/automated-cocoapod-releases-with-github-actions-8526dd4535c7) or [here](https://github.com/marketplace/actions/deploy-to-cocoapod-action). Note that you should do this before creating new release and you don't need to make initial release on your local machine.