### PR TITLE
Adding a way to choose background color, or disable it

### DIFF
--- a/Sources/QRCodeGenerator/QRCode.swift
+++ b/Sources/QRCodeGenerator/QRCode.swift
@@ -246,7 +246,7 @@ public struct QRCode {
     /// this QR Code, with the given number of border modules.
     /// 
     /// The string always uses Unix newlines (\n), regardless of the platform.
-    public func toSVGString(border: Int, width: Int? = nil) -> String {
+    public func toSVGString(border: Int, width: Int? = nil, background: String? = "#FFFFFF") -> String {
         assert(border >= 0, "Border must be non-negative")
         let dimension = size + (border * 2)
         let path = (0..<size).map { y in
@@ -257,11 +257,12 @@ public struct QRCode {
             }.joined()
         }.joined()
         let widthAttribute = width.map { "width=\($0)" } ?? ""
+        let backgroundRect = background.map { "<rect width=\"100%\" height=\"100%\" fill=\"\($0)\"/>" } ?? ""
         return """
             <?xml version="1.0" encoding="UTF-8"?>
             <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
             <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 \(dimension) \(dimension)" stroke="none"\(widthAttribute)>
-              <rect width="100%" height="100%" fill="#FFFFFF"/>
+              \(backgroundRect)
               <path d="\(path)" fill="#000000"/>
             </svg>
             """


### PR DESCRIPTION
The background of the SVG string can now be customized using the `background` parameter.