### PR TITLE
Set minimum macos version to 10.11 to fix Cocoapods Xcode 14.3+ issue

### DIFF
--- a/SwiftQRCodeGenerator.podspec
+++ b/SwiftQRCodeGenerator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                      = 'SwiftQRCodeGenerator'
-  s.version                   = '1.0.4'
+  s.version                   = '2.0.0'
   s.summary                   = 'QR code generator written in pure Swift'
   s.homepage                  = 'https://github.com/fwcd/swift-qrcode-generator'
   s.license                   = { :type => 'MIT', :file => 'LICENSE' }
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target     = '9.0'
   s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '2.0'
-  s.osx.deployment_target     = '10.10'
+  s.osx.deployment_target     = '10.11'
   s.module_name               = 'QRCodeGenerator'
   s.source_files              = 'Sources/**/*'
   s.frameworks                = 'Foundation'


### PR DESCRIPTION
When Xcode 14.3 came out, they've removed a library called libarclitemacos.a from the installation. This means that cocoapods builds with macos targets < 10.11 will fail, as it will attempt to link against this missing library.

See the bug here :-  https://github.com/CocoaPods/CocoaPods/issues/11839

There has been discussion regarding implementing flags in cocoapods to work around the issue but this has yet to materialize.

It appears that the only possible solution at this point is to increase the minimum macos version in a podspec to 10.11 to avoid linking against libarclite_macosx.a.

The current ios, tvos and watchos minimum deployment targets are fine.

If we tag this change as v2.0.0, people who still require use of macos 10.10 (and older versions of Xcode) via Cocoapods can still link against the current v1.4.0.